### PR TITLE
feat: enable variable editing in prompts

### DIFF
--- a/src/components/PromptVariablesDialog.tsx
+++ b/src/components/PromptVariablesDialog.tsx
@@ -1,0 +1,165 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { updatePromptPreview, PromptVariable, loadStoredVariables, saveVariableValues } from "@/lib/utils/prompt-variables";
+import { slugify } from '@/lib/utils/string';
+import { Check, Loader2 } from "lucide-react";
+
+export interface PromptVariablesDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  prompt: string;
+  act: string;
+  variables: PromptVariable[];
+}
+
+export function PromptVariablesDialog({
+  isOpen,
+  onClose,
+  prompt,
+  act,
+  variables,
+}: PromptVariablesDialogProps) {
+  const [editedValues, setEditedValues] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Simplified useEffect
+  useEffect(() => {
+    if (isOpen) {
+      const stored = loadStoredVariables();
+      const key = slugify(act);
+      const storedData = stored[key];
+      setEditedValues(storedData?.values || {});
+    }
+  }, [isOpen, prompt, act]);
+
+  const handleInputChange = (name: string, value: string) => {
+    setEditedValues(prevValues => {
+      const newValues = { ...prevValues, [name]: value };
+      //onUpdate(processedPrompt);
+      return newValues;
+    });
+    setSaveSuccess(false);
+  };
+
+  const handleSave = () => {
+    setIsSaving(true);
+    setSaveSuccess(false);
+    try {
+      saveVariableValues(act, editedValues, variables);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 2000);
+    } catch (error) {
+      console.error('Failed to save variable values:', error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRestoreDefaults = () => {
+    // Create default values object with empty strings for non-default fields
+    const defaultValues = Object.fromEntries(
+      variables.map(v => [v.name, ''])
+    );
+    
+    // Reset all inputs and values
+    const inputs = document.querySelectorAll('.variable-input') as NodeListOf<HTMLInputElement>;
+    inputs.forEach(input => {
+      input.value = '';
+      const variable = variables.find(v => v.name === input.id);
+      if (variable?.default) {
+        input.placeholder = variable.default;
+      }
+    });
+
+    setEditedValues(defaultValues);
+    setSaveSuccess(false);
+  };
+
+  const hasChangesToRestore = () => {
+    return Object.entries(editedValues).some(([_, value]) => {
+      return value !== '';  // If any value is non-empty, there's something to restore
+    });
+  };
+
+  const hasChangesToSave = () => {
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    const storedData = stored[key]?.values || {};
+    
+    return Object.entries(editedValues).some(([name, value]) => {
+      return value !== (storedData[name] || '');  // Compare with stored values
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md max-h-[80vh] overflow-y-auto flex flex-col p-6">
+        <DialogHeader>
+          <DialogTitle>Edit Variables</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-6 flex-1 overflow-y-auto pb-4">
+          <div className="grid gap-6 px-1">
+            {variables.map((variable) => (
+              <div key={variable.name} className="flex flex-col gap-2">
+                <Label htmlFor={variable.name} className="text-left font-medium">
+                  {variable.name}
+                </Label>
+                <div className="">
+                  <Input
+                    id={variable.name}
+                    value={editedValues[variable.name] ?? ''}
+                    onChange={(e) => handleInputChange(variable.name, e.currentTarget.value)}
+                    placeholder={variable.default || `Enter ${variable.name}`}
+                    className="col-span-3 variable-input ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 outline-none"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Preview</Label>
+            <div 
+              className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground"
+              dangerouslySetInnerHTML={{ 
+                __html: updatePromptPreview(prompt, editedValues) 
+              }}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex justify-between mt-4 pt-4 border-t">
+          <Button
+            variant="outline"
+            onClick={handleRestoreDefaults}
+            disabled={!hasChangesToRestore()}
+            className="w-full"
+          >
+            Restore Defaults
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || !hasChangesToSave()}
+            className="w-full"
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : saveSuccess ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/lib/utils/prompt-variables.ts
+++ b/src/lib/utils/prompt-variables.ts
@@ -1,0 +1,165 @@
+import { slugify } from './string';
+
+export interface PromptVariable {
+  name: string;
+  default?: string;
+}
+
+export interface StoredPromptData {
+  act: string;
+  values: Record<string, string>;
+  lastUpdated: number;
+}
+
+export type StoredVariables = Record<string, StoredPromptData>;
+
+export function extractVariables(text: string): PromptVariable[] {
+  const patterns = [
+    /\${([^}]+)}/g,  // ${var:default}
+    /\{\{([^}]+)\}\}/g  // {{var}}
+  ];
+  
+  const variables: PromptVariable[] = [];
+  
+  patterns.forEach(regex => {
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const [variable, defaultValue] = match[1].split(':').map(s => s.trim());
+      if (variable) {
+        variables.push({ name: variable, default: defaultValue || '' });
+      }
+    }
+  });
+
+  // Remove duplicates by name
+  return Array.from(
+    new Map(variables.map(v => [v.name, v])).values()
+  );
+}
+
+export const updatePromptPreview = (
+  promptText: string,
+  values?: Record<string, string>,
+  act?: string
+): string => {
+  const variables = extractVariables(promptText);
+
+  if (variables.length === 0) {
+    return promptText;
+  }
+
+  // If values not provided but act is, try to load from storage
+  if (!values && act) {
+    try {
+      const stored = loadStoredVariables();
+      const key = slugify(act);
+      const storedData = stored[key];
+      
+      values = Object.fromEntries(
+        variables.map(v => {
+          const storedValue = storedData?.values?.[v.name];
+          return [v.name, storedValue !== undefined ? storedValue : v.default || ''];
+        })
+      );
+    } catch (error) {
+      console.error('Error loading stored variables:', error);
+    }
+  }
+
+  let previewText = promptText;
+
+  // When no values provided and no stored values found
+  if (!values) {
+    variables.forEach(variable => {
+      const pattern = new RegExp(`\\$\{${variable.name}[^}]*\}`, 'g');
+      const replacement = variable.default || `<b>${variable.name}</b>`;
+      previewText = previewText.replace(pattern, replacement);
+    });
+    return previewText;
+  }
+
+  // Replace variables with user inputs or defaults
+  variables.forEach(variable => {
+    const pattern = new RegExp(`\\$\{${variable.name}[^}]*\}`, 'g');
+    const value = values[variable.name]?.trim();
+    let replacement;
+
+    if (value) {
+      replacement = value; // User entered value
+    } else if (variable.default) {
+      replacement = variable.default; // Show default value
+    } else {
+      replacement = variable.name; // No value or default, show variable name
+    }
+    replacement = `<b>${replacement}</b>`;
+
+    previewText = previewText.replace(pattern, replacement);
+  });
+
+  // Also handle {{var}} format
+  previewText = previewText.replace(/\{\{([^}]+)\}\}/g, (_, name) => {
+    const value = values[name]?.trim();
+    return value ? `<b>${value}</b>` : `<b>{{${name}}}</b>`;
+  });
+
+  return previewText;
+};
+
+export function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+const STORAGE_KEY = 'prompt_variables';
+
+export const loadStoredVariables = (): StoredVariables => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch (error) {
+    console.error('Error loading stored variables:', error);
+    return {};
+  }
+};
+
+export const removeStoredVariables = (act: string): void => {
+  try {
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    delete stored[key];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    console.error('Error removing stored variables:', error);
+  }
+};
+
+export const saveVariableValues = (
+  act: string,
+  values: Record<string, string>,
+  variables: PromptVariable[]
+): void => {
+  try {
+    // Check if all values are empty (restored to defaults)
+    const allEmpty = variables.every(variable => 
+      !values[variable.name] || values[variable.name].trim() === ''
+    );
+
+    if (allEmpty) {
+      // If all values are empty/default, remove from storage
+      removeStoredVariables(act);
+      return;
+    }
+
+    // Save as normal
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    
+    stored[key] = {
+      act,
+      values,
+      lastUpdated: Date.now()
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    console.error('Error saving variable values:', error);
+  }
+};

--- a/src/lib/utils/storage.ts
+++ b/src/lib/utils/storage.ts
@@ -1,6 +1,54 @@
 import { useEffect, useState } from 'react';
 import { AI_MODELS } from '../constants';
 
+declare global {
+  const browser: typeof chrome;
+}
+
+interface StorageWrapper {
+  sync: {
+    get: <T>(key?: string | string[] | object) => Promise<T>;
+    set: (items: object) => Promise<void>;
+    onChanged: {
+      addListener: (callback: (changes: { [key: string]: chrome.storage.StorageChange }) => void) => void;
+      removeListener: (callback: (changes: { [key: string]: chrome.storage.StorageChange }) => void) => void;
+    };
+  };
+}
+
+// Create a safer storage access wrapper
+const createStorageWrapper = (): StorageWrapper => {
+  const browserAPI = typeof chrome !== 'undefined' ? chrome : typeof browser !== 'undefined' ? browser : undefined;
+  const syncStorage = browserAPI?.storage?.sync;
+
+  if (!syncStorage) {
+    console.warn('Storage API not available, using fallback storage');
+    return {
+      sync: {
+        get: async <T>(key?: string | string[] | object): Promise<T> => {
+          console.debug('Fallback storage get:', key);
+          return {} as T;
+        },
+        set: async (items: object) => {
+          console.debug('Fallback storage set:', items);
+        },
+        onChanged: {
+          addListener: () => {
+            console.debug('Fallback storage addListener');
+          },
+          removeListener: () => {
+            console.debug('Fallback storage removeListener');
+          }
+        }
+      }
+    };
+  }
+
+  return { sync: syncStorage as StorageWrapper['sync'] };
+};
+
+const storage = createStorageWrapper();
+
 export interface StorageData {
   selectedModel: string;
   isDarkMode: boolean;
@@ -22,7 +70,7 @@ export function useStorage<K extends keyof StorageData>({
   useEffect(() => {
     let isMounted = true;
 
-    chrome.storage.sync.get(key).then(result => {
+    void storage.sync.get<{[key: string]: StorageData[K]}>(key).then(result => {
       if (isMounted) {
         setValue(result[key] ?? defaultValue);
         setIsLoading(false);
@@ -35,11 +83,11 @@ export function useStorage<K extends keyof StorageData>({
       }
     };
 
-    chrome.storage.sync.onChanged.addListener(handleChange);
+    storage.sync.onChanged.addListener(handleChange);
 
     return () => {
       isMounted = false;
-      chrome.storage.sync.onChanged.removeListener(handleChange);
+      storage.sync.onChanged.removeListener(handleChange);
     };
   }, [key, defaultValue]);
 
@@ -48,7 +96,7 @@ export function useStorage<K extends keyof StorageData>({
       if (key === 'selectedModel' && !AI_MODELS.some(model => model.id === newValue)) {
         throw new Error('Invalid model ID');
       }
-      await chrome.storage.sync.set({ [key]: newValue });
+      await storage.sync.set({ [key]: newValue });
       setValue(newValue);
     } catch (error) {
       console.error(`Error saving storage value for ${key}:`, error);

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -1,0 +1,8 @@
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Description

- Added functionality to allow users to edit variables in prompts when they contain variables. Implemented in prompt.chat.
- Fixed an execution issue in storage.ts due to local storage access limitations in Chrome. Open for feedback if this change is unnecessary.

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactor
- [ ] Other (please describe):

## Testing
The "Act as DevOps Engineer" prompt contains three editable variables. The title variable was modified and successfully saved to local storage for future use.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/9f86c440-dc12-4dc8-a7a4-e2f608fe646c)
![image](https://github.com/user-attachments/assets/7f4d1d53-cd2c-4d58-b916-46abc1ecc0c5)

