### PR TITLE
Feat/Favorites Tab Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.1.7",
     "class-variance-authority": "^0.7.1",

--- a/src/components/PromptCard.tsx
+++ b/src/components/PromptCard.tsx
@@ -1,3 +1,4 @@
+import { PromptVariablesDialog } from "@/components/PromptVariablesDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,25 +11,26 @@ import { AI_MODELS } from "@/lib/constants";
 import { usePrompts } from "@/lib/contexts/PromptsContext";
 import { AIModel } from "@/lib/types";
 import { usePromptInAI } from "@/lib/utils/ai-interactions";
-import { Check, ChevronDown, ChevronUp, Copy, Edit2 } from "lucide-react";
-import { useEffect, useState } from "react";
-import { PromptVariablesDialog } from "@/components/PromptVariablesDialog";
-import { extractVariables, updatePromptPreview, loadStoredVariables } from "@/lib/utils/prompt-variables";
+import { extractVariables, loadStoredVariables, updatePromptPreview } from "@/lib/utils/prompt-variables";
 import { slugify } from '@/lib/utils/string';
+import { Check, ChevronDown, ChevronUp, Copy, Edit2, Star } from "lucide-react";
+import { useEffect, useState } from "react";
 
 interface PromptCardProps {
   act: string;
   prompt: string;
   contributor: string;
   searchQuery?: string;
+  isFavorite: boolean;
 }
 
 export function PromptCard({
   act,
   prompt,
   contributor,
+  isFavorite,
 }: PromptCardProps) {
-  const { selectedModel, setSelectedModel, query: searchQuery } = usePrompts();
+  const { selectedModel, setSelectedModel, query: searchQuery, toggleFavorite } = usePrompts();
   const [isOpen, setIsOpen] = useState(!!searchQuery);
   const { copy } = useCopy();
   const [isCopied, setIsCopied] = useState(false);
@@ -44,6 +46,7 @@ export function PromptCard({
   };
   const [isLoading, setIsLoading] = useState(false);
   const [isEditingVariables, setIsEditingVariables] = useState(false);
+  const [isCurrentFavorite, setIsCurrentFavorite] = useState(isFavorite);
 
   const variables = extractVariables(prompt);
   const hasVariables = variables.length > 0;
@@ -80,6 +83,13 @@ export function PromptCard({
     }
   };
 
+  const handleToggleFavorite = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const newState = toggleFavorite(`${act}-${prompt}`);
+    setIsCurrentFavorite(newState);
+  };
+
   const displayPrompt = updatePromptPreview(prompt, undefined, hasVariables ? act : undefined);
 
   return (
@@ -87,6 +97,14 @@ export function PromptCard({
       <div className="p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="text-base font-bold">{act}</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleToggleFavorite}
+            className={`p-1 hover:bg-transparent ${isCurrentFavorite ? 'text-yellow-500' : 'text-muted-foreground'}`}
+          >
+            <Star className="h-5 w-5" fill={isCurrentFavorite ? 'currentColor' : 'none'} />
+          </Button>
         </div>
 
         <div className="flex flex-col gap-2">

--- a/src/components/PromptVariablesDialog.tsx
+++ b/src/components/PromptVariablesDialog.tsx
@@ -1,0 +1,165 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { updatePromptPreview, PromptVariable, loadStoredVariables, saveVariableValues } from "@/lib/utils/prompt-variables";
+import { slugify } from '@/lib/utils/string';
+import { Check, Loader2 } from "lucide-react";
+
+export interface PromptVariablesDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  prompt: string;
+  act: string;
+  variables: PromptVariable[];
+}
+
+export function PromptVariablesDialog({
+  isOpen,
+  onClose,
+  prompt,
+  act,
+  variables,
+}: PromptVariablesDialogProps) {
+  const [editedValues, setEditedValues] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Simplified useEffect
+  useEffect(() => {
+    if (isOpen) {
+      const stored = loadStoredVariables();
+      const key = slugify(act);
+      const storedData = stored[key];
+      setEditedValues(storedData?.values || {});
+    }
+  }, [isOpen, prompt, act]);
+
+  const handleInputChange = (name: string, value: string) => {
+    setEditedValues(prevValues => {
+      const newValues = { ...prevValues, [name]: value };
+      //onUpdate(processedPrompt);
+      return newValues;
+    });
+    setSaveSuccess(false);
+  };
+
+  const handleSave = () => {
+    setIsSaving(true);
+    setSaveSuccess(false);
+    try {
+      saveVariableValues(act, editedValues, variables);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 2000);
+    } catch (error) {
+      console.error('Failed to save variable values:', error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRestoreDefaults = () => {
+    // Create default values object with empty strings for non-default fields
+    const defaultValues = Object.fromEntries(
+      variables.map(v => [v.name, ''])
+    );
+    
+    // Reset all inputs and values
+    const inputs = document.querySelectorAll('.variable-input') as NodeListOf<HTMLInputElement>;
+    inputs.forEach(input => {
+      input.value = '';
+      const variable = variables.find(v => v.name === input.id);
+      if (variable?.default) {
+        input.placeholder = variable.default;
+      }
+    });
+
+    setEditedValues(defaultValues);
+    setSaveSuccess(false);
+  };
+
+  const hasChangesToRestore = () => {
+    return Object.entries(editedValues).some(([_, value]) => {
+      return value !== '';  // If any value is non-empty, there's something to restore
+    });
+  };
+
+  const hasChangesToSave = () => {
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    const storedData = stored[key]?.values || {};
+    
+    return Object.entries(editedValues).some(([name, value]) => {
+      return value !== (storedData[name] || '');  // Compare with stored values
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md max-h-[80vh] overflow-y-auto flex flex-col p-6">
+        <DialogHeader>
+          <DialogTitle>Edit Variables</DialogTitle>
+        </DialogHeader>
+        
+        <div className="space-y-6 flex-1 overflow-y-auto pb-4">
+          <div className="grid gap-6 px-1">
+            {variables.map((variable) => (
+              <div key={variable.name} className="flex flex-col gap-2">
+                <Label htmlFor={variable.name} className="text-left font-medium">
+                  {variable.name}
+                </Label>
+                <div className="">
+                  <Input
+                    id={variable.name}
+                    value={editedValues[variable.name] ?? ''}
+                    onChange={(e) => handleInputChange(variable.name, e.currentTarget.value)}
+                    placeholder={variable.default || `Enter ${variable.name}`}
+                    className="col-span-3 variable-input ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 outline-none"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Preview</Label>
+            <div 
+              className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground"
+              dangerouslySetInnerHTML={{ 
+                __html: updatePromptPreview(prompt, editedValues) 
+              }}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex justify-between mt-4 pt-4 border-t">
+          <Button
+            variant="outline"
+            onClick={handleRestoreDefaults}
+            disabled={!hasChangesToRestore()}
+            className="w-full"
+          >
+            Restore Defaults
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || !hasChangesToSave()}
+            className="w-full"
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : saveSuccess ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PromptsList.tsx
+++ b/src/components/PromptsList.tsx
@@ -1,11 +1,22 @@
 import { usePrompts } from "@/lib/contexts/PromptsContext";
 import { useMemo } from "react";
 import { PromptCard } from "./PromptCard";
-
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+import { List, Star } from "lucide-react";
 
 export function PromptsList() {
-  const { devMode, filteredPrompts, prompts, query: searchQuery } = usePrompts();
+  const { devMode, filteredPrompts, prompts, query: searchQuery, activeTab, setActiveTab, favorites } = usePrompts();
   const totalCount = prompts.length;
+  const totalFavorites = favorites.size;
+  
+  const filteredFavorites = useMemo(() => {
+    return filteredPrompts.filter(prompt => favorites.has(`${prompt.act}-${prompt.prompt}`));
+  }, [filteredPrompts, favorites]);
+
+  const displayedPrompts = useMemo(() => {
+    return activeTab === 'favorites' ? filteredFavorites : filteredPrompts;
+  }, [activeTab, filteredPrompts, filteredFavorites]);
+
   const filterDescription = useMemo(() => {
     const filteredCount = filteredPrompts.length;
 
@@ -15,23 +26,62 @@ export function PromptsList() {
     return `Showing ${filteredCount} of ${totalCount} prompts${devMode ? ' (Developer Mode)' : ''}`;
   }, [filteredPrompts.length, totalCount, searchQuery, devMode]);
 
+  const filterFavoritesDescription = useMemo(() => {
+    const filteredFavoritesCount = filteredFavorites.length;
+    if (filteredFavoritesCount === totalFavorites) {
+      return `${filteredFavoritesCount} favorites`;
+    }
+    return `Showing ${filteredFavoritesCount} of ${totalFavorites} favorites${devMode ? ' (Developer Mode)' : ''}`;
+  }, [filteredFavorites.length, totalFavorites, searchQuery, devMode]);
+
   return (
     <div className="space-y-4">
+      <Tabs 
+        value={activeTab} 
+        onValueChange={(value) => setActiveTab(value as 'all' | 'favorites')}
+      >
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="all">
+            <div className="flex flex-row items-center justify-center gap-2">
+              <List size={16} />
+              All</div>
+            </TabsTrigger>
+          <TabsTrigger value="favorites"><div className="flex flex-row items-center justify-center gap-2">
+              <Star size={16} />
+              Favorites</div></TabsTrigger>
+        </TabsList>
+      </Tabs>
+
       <div className="px-1">
         <span className="text-sm text-muted-foreground">
-          {filterDescription}
+          {activeTab==='all' ? filterDescription:filterFavoritesDescription}
         </span>
       </div>
 
       <div className="space-y-3">
-        {filteredPrompts.map((prompt, index) => (
-          <PromptCard
-            key={`${prompt.act}-${index}`}
-            act={prompt.act}
-            prompt={prompt.prompt}
-            contributor={prompt.contributor || '@f'}
-          />
-        ))}
+        {displayedPrompts.length > 0 ? (
+          displayedPrompts.map((prompt, index) => (
+            <PromptCard
+              key={`${prompt.act}-${index}`}
+              act={prompt.act}
+              prompt={prompt.prompt}
+              contributor={prompt.contributor || '@f'}
+              isFavorite={favorites.has(`${prompt.act}-${prompt.prompt}`)}
+            />
+          ))
+        ) : (
+          activeTab === "favorites" ? (
+            <div className="text-center py-8 text-muted-foreground space-y-1">
+              <p className="text-base font-medium">Your favorites list is empty</p>
+              <p className="text-sm">Click the star icon on any prompt to save it here</p>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-muted-foreground space-y-1">
+              <p className="text-base font-medium">No matching prompts</p>
+              <p className="text-sm">Try different search terms or clear filters</p>
+            </div>
+          )
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,14 @@
     @apply bg-background text-foreground;
   }
 }
+
+
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/lib/contexts/PromptsContext.tsx
+++ b/src/lib/contexts/PromptsContext.tsx
@@ -2,8 +2,9 @@ import { AI_MODELS } from "@/lib/constants";
 import { Prompt, fetchPrompts } from "@/lib/utils/prompts";
 import { useStorage } from "@/lib/utils/storage";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { isFavorite } from "../utils/favorites";
 
-interface PromptsContextType {
+export type PromptsContextType = {
   prompts: Prompt[];
   filteredPrompts: Prompt[];
   isLoading: boolean;
@@ -12,11 +13,17 @@ interface PromptsContextType {
   devMode: boolean;
   selectedModel: string;
   isDarkMode: boolean;
+  showFavorites: boolean;
   setIsDarkMode: (newValue: boolean) => Promise<void>;
   setQuery: (query: string) => void;
   setDevMode: (newValue: boolean) => Promise<void>;
   setSelectedModel: (newValue: string) => Promise<void>;
-}
+  setShowFavorites: (show: boolean) => void;
+  favorites: Set<string>;
+  toggleFavorite: (promptId: string) => boolean;
+  activeTab: 'all' | 'favorites';
+  setActiveTab: (tab: 'all' | 'favorites') => void;
+};
 
 const PromptsContext = createContext<PromptsContextType | undefined>(undefined);
 
@@ -25,6 +32,12 @@ export function PromptsProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [query, setQuery] = useState("");
+  const [showFavorites, setShowFavorites] = useState(false);
+  const [favorites, setFavorites] = useState<Set<string>>(() => {
+    const saved = localStorage.getItem('promptFavorites');
+    return new Set(saved ? JSON.parse(saved) : []);
+  });
+  const [activeTab, setActiveTab] = useState<'all' | 'favorites'>('all');
 
   const { value: selectedModel, setValue: setSelectedModel, isLoading: isModelLoading } = useStorage({
     key: 'selectedModel',
@@ -53,17 +66,43 @@ export function PromptsProvider({ children }: { children: React.ReactNode }) {
       .finally(() => setIsLoading(false));
   }, []);
 
-  const filteredPrompts = prompts
-    .filter(prompt => {
-      const matchesSearch = !query ||
-        prompt.act.toLowerCase().includes(query.toLowerCase()) ||
-        prompt.prompt.toLowerCase().includes(query.toLowerCase());
+  const toggleFavorite = (promptId: string): boolean => {
+    setFavorites(prev => {
+      const newFavorites = new Set(prev);
+      if (newFavorites.has(promptId)) {
+        newFavorites.delete(promptId);
+      } else {
+        newFavorites.add(promptId);
+      }
+      localStorage.setItem('promptFavorites', JSON.stringify(Array.from(newFavorites)));
+      return newFavorites;
+    });
+    return !favorites.has(promptId);
+  };
 
-      const matchesDevMode = !devMode || prompt.for_devs === true;
+  const filteredPrompts = useMemo(() => {
+    let filtered = prompts;
+    
+    if (showFavorites) {
+      filtered = filtered.filter(p => isFavorite(p.act));
+    }
+    
+    if (query) {
+      filtered = filtered.filter(
+        prompt => {
+          const matchesSearch = !query ||
+            prompt.act.toLowerCase().includes(query.toLowerCase()) ||
+            prompt.prompt.toLowerCase().includes(query.toLowerCase());
 
-      return matchesSearch && matchesDevMode;
-    })
-    .sort((a, b) => a.act.localeCompare(b.act));
+          const matchesDevMode = !devMode || prompt.for_devs === true;
+
+          return matchesSearch && matchesDevMode;
+        }
+      );
+    }
+    
+    return filtered.sort((a, b) => a.act.localeCompare(b.act));
+  }, [prompts, query, showFavorites, devMode]);
 
   const value = useMemo(() => ({
     prompts,
@@ -74,10 +113,16 @@ export function PromptsProvider({ children }: { children: React.ReactNode }) {
     devMode,
     selectedModel,
     isDarkMode,
+    showFavorites,
     setIsDarkMode,
     setQuery,
     setDevMode,
     setSelectedModel,
+    setShowFavorites,
+    favorites,
+    toggleFavorite,
+    activeTab,
+    setActiveTab,
   }), [
     prompts,
     filteredPrompts,
@@ -88,10 +133,16 @@ export function PromptsProvider({ children }: { children: React.ReactNode }) {
     devMode,
     selectedModel,
     isDarkMode,
+    showFavorites,
     setIsDarkMode,
     setQuery,
     setDevMode,
-    setSelectedModel
+    setSelectedModel,
+    setShowFavorites,
+    favorites,
+    toggleFavorite,
+    activeTab,
+    setActiveTab
   ]);
 
   return (

--- a/src/lib/utils/favorites.ts
+++ b/src/lib/utils/favorites.ts
@@ -1,0 +1,28 @@
+import { slugify } from './string';
+
+const FAVORITES_KEY = 'favorite_prompts';
+
+export function getFavorites(): string[] {
+  const stored = localStorage.getItem(FAVORITES_KEY);
+  return stored ? JSON.parse(stored) : [];
+}
+
+export function toggleFavorite(actAs: string): boolean {
+  const favorites = getFavorites();
+  const id = slugify(actAs);
+  const index = favorites.indexOf(id);
+  
+  if (index === -1) {
+    favorites.push(id);
+  } else {
+    favorites.splice(index, 1);
+  }
+  
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+  return index === -1;
+}
+
+export function isFavorite(actAs: string): boolean {
+  const favorites = getFavorites();
+  return favorites.includes(slugify(actAs));
+}

--- a/src/lib/utils/prompt-variables.ts
+++ b/src/lib/utils/prompt-variables.ts
@@ -1,0 +1,165 @@
+import { slugify } from './string';
+
+export interface PromptVariable {
+  name: string;
+  default?: string;
+}
+
+export interface StoredPromptData {
+  act: string;
+  values: Record<string, string>;
+  lastUpdated: number;
+}
+
+export type StoredVariables = Record<string, StoredPromptData>;
+
+export function extractVariables(text: string): PromptVariable[] {
+  const patterns = [
+    /\${([^}]+)}/g,  // ${var:default}
+    /\{\{([^}]+)\}\}/g  // {{var}}
+  ];
+  
+  const variables: PromptVariable[] = [];
+  
+  patterns.forEach(regex => {
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const [variable, defaultValue] = match[1].split(':').map(s => s.trim());
+      if (variable) {
+        variables.push({ name: variable, default: defaultValue || '' });
+      }
+    }
+  });
+
+  // Remove duplicates by name
+  return Array.from(
+    new Map(variables.map(v => [v.name, v])).values()
+  );
+}
+
+export const updatePromptPreview = (
+  promptText: string,
+  values?: Record<string, string>,
+  act?: string
+): string => {
+  const variables = extractVariables(promptText);
+
+  if (variables.length === 0) {
+    return promptText;
+  }
+
+  // If values not provided but act is, try to load from storage
+  if (!values && act) {
+    try {
+      const stored = loadStoredVariables();
+      const key = slugify(act);
+      const storedData = stored[key];
+      
+      values = Object.fromEntries(
+        variables.map(v => {
+          const storedValue = storedData?.values?.[v.name];
+          return [v.name, storedValue !== undefined ? storedValue : v.default || ''];
+        })
+      );
+    } catch (error) {
+      console.error('Error loading stored variables:', error);
+    }
+  }
+
+  let previewText = promptText;
+
+  // When no values provided and no stored values found
+  if (!values) {
+    variables.forEach(variable => {
+      const pattern = new RegExp(`\\$\{${variable.name}[^}]*\}`, 'g');
+      const replacement = variable.default || `<b>${variable.name}</b>`;
+      previewText = previewText.replace(pattern, replacement);
+    });
+    return previewText;
+  }
+
+  // Replace variables with user inputs or defaults
+  variables.forEach(variable => {
+    const pattern = new RegExp(`\\$\{${variable.name}[^}]*\}`, 'g');
+    const value = values[variable.name]?.trim();
+    let replacement;
+
+    if (value) {
+      replacement = value; // User entered value
+    } else if (variable.default) {
+      replacement = variable.default; // Show default value
+    } else {
+      replacement = variable.name; // No value or default, show variable name
+    }
+    replacement = `<b>${replacement}</b>`;
+
+    previewText = previewText.replace(pattern, replacement);
+  });
+
+  // Also handle {{var}} format
+  previewText = previewText.replace(/\{\{([^}]+)\}\}/g, (_, name) => {
+    const value = values[name]?.trim();
+    return value ? `<b>${value}</b>` : `<b>{{${name}}}</b>`;
+  });
+
+  return previewText;
+};
+
+export function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+const STORAGE_KEY = 'prompt_variables';
+
+export const loadStoredVariables = (): StoredVariables => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch (error) {
+    console.error('Error loading stored variables:', error);
+    return {};
+  }
+};
+
+export const removeStoredVariables = (act: string): void => {
+  try {
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    delete stored[key];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    console.error('Error removing stored variables:', error);
+  }
+};
+
+export const saveVariableValues = (
+  act: string,
+  values: Record<string, string>,
+  variables: PromptVariable[]
+): void => {
+  try {
+    // Check if all values are empty (restored to defaults)
+    const allEmpty = variables.every(variable => 
+      !values[variable.name] || values[variable.name].trim() === ''
+    );
+
+    if (allEmpty) {
+      // If all values are empty/default, remove from storage
+      removeStoredVariables(act);
+      return;
+    }
+
+    // Save as normal
+    const stored = loadStoredVariables();
+    const key = slugify(act);
+    
+    stored[key] = {
+      act,
+      values,
+      lastUpdated: Date.now()
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    console.error('Error saving variable values:', error);
+  }
+};

--- a/src/lib/utils/storage.ts
+++ b/src/lib/utils/storage.ts
@@ -1,6 +1,54 @@
 import { useEffect, useState } from 'react';
 import { AI_MODELS } from '../constants';
 
+declare global {
+  const browser: typeof chrome;
+}
+
+interface StorageWrapper {
+  sync: {
+    get: <T>(key?: string | string[] | object) => Promise<T>;
+    set: (items: object) => Promise<void>;
+    onChanged: {
+      addListener: (callback: (changes: { [key: string]: chrome.storage.StorageChange }) => void) => void;
+      removeListener: (callback: (changes: { [key: string]: chrome.storage.StorageChange }) => void) => void;
+    };
+  };
+}
+
+// Create a safer storage access wrapper
+const createStorageWrapper = (): StorageWrapper => {
+  const browserAPI = typeof chrome !== 'undefined' ? chrome : typeof browser !== 'undefined' ? browser : undefined;
+  const syncStorage = browserAPI?.storage?.sync;
+
+  if (!syncStorage) {
+    console.warn('Storage API not available, using fallback storage');
+    return {
+      sync: {
+        get: async <T>(key?: string | string[] | object): Promise<T> => {
+          console.debug('Fallback storage get:', key);
+          return {} as T;
+        },
+        set: async (items: object) => {
+          console.debug('Fallback storage set:', items);
+        },
+        onChanged: {
+          addListener: () => {
+            console.debug('Fallback storage addListener');
+          },
+          removeListener: () => {
+            console.debug('Fallback storage removeListener');
+          }
+        }
+      }
+    };
+  }
+
+  return { sync: syncStorage as StorageWrapper['sync'] };
+};
+
+const storage = createStorageWrapper();
+
 export interface StorageData {
   selectedModel: string;
   isDarkMode: boolean;
@@ -22,7 +70,7 @@ export function useStorage<K extends keyof StorageData>({
   useEffect(() => {
     let isMounted = true;
 
-    chrome.storage.sync.get(key).then(result => {
+    void storage.sync.get<{[key: string]: StorageData[K]}>(key).then(result => {
       if (isMounted) {
         setValue(result[key] ?? defaultValue);
         setIsLoading(false);
@@ -35,11 +83,11 @@ export function useStorage<K extends keyof StorageData>({
       }
     };
 
-    chrome.storage.sync.onChanged.addListener(handleChange);
+    storage.sync.onChanged.addListener(handleChange);
 
     return () => {
       isMounted = false;
-      chrome.storage.sync.onChanged.removeListener(handleChange);
+      storage.sync.onChanged.removeListener(handleChange);
     };
   }, [key, defaultValue]);
 
@@ -48,7 +96,7 @@ export function useStorage<K extends keyof StorageData>({
       if (key === 'selectedModel' && !AI_MODELS.some(model => model.id === newValue)) {
         throw new Error('Invalid model ID');
       }
-      await chrome.storage.sync.set({ [key]: newValue });
+      await storage.sync.set({ [key]: newValue });
       setValue(newValue);
     } catch (error) {
       console.error(`Error saving storage value for ${key}:`, error);

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -1,0 +1,8 @@
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,21 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-controllable-state" "1.1.0"
 
+"@radix-ui/react-roving-focus@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.2.tgz#815d051a54299114a68db6eb8d34c41a3c0a646f"
+  integrity sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-collection" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+
 "@radix-ui/react-select@^2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.6.tgz#79c07cac4de0188e6f7afb2720a87a0405d88849"
@@ -823,6 +838,20 @@
     "@radix-ui/react-use-controllable-state" "1.1.0"
     "@radix-ui/react-use-previous" "1.1.0"
     "@radix-ui/react-use-size" "1.1.0"
+
+"@radix-ui/react-tabs@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.3.tgz#c47c8202dc676dea47676215863d2ef9b141c17a"
+  integrity sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-roving-focus" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
 
 "@radix-ui/react-toast@^1.2.5":
   version "1.2.5"
@@ -2621,8 +2650,16 @@ source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2640,8 +2677,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows users to save prompts to local storage, enabling persistent access to frequently used prompts. The implementation builds upon the previous (yet unmerged) PR #2 , which introduced functionality for editing prompt variables. Since the current development relies on the changes from that PR, this branch extends and refines the existing implementation.

Change(s) & Improvement(s)
Added functionality to store saved prompts in local storage.
Notes
This PR depends on the previous PR (Edit Variables for Prompts). If necessary, the changes can be rebased or adjusted based on the final state of the earlier PR.
Feedback is welcome on improving the persistence mechanism and integrating it smoothly with the existing workflow.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactor
- [ ] Other (please describe):

## Testing
You can favorite prompts by clicking the star icon on the right-top corner. Then list them on the favorites tab.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/b61cb7f9-4a12-436f-be58-54e02f65ed53)

