### PR TITLE
fix: add build verification before release and fix popup context detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Verify build
+        run: yarn build
+
       - name: Semantic Release
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
@@ -52,7 +55,7 @@ jobs:
         if: steps.semantic.outputs.new_release_published == 'true'
         run: yarn install --frozen-lockfile
 
-      - name: Build
+      - name: Build for release
         if: steps.semantic.outputs.new_release_published == 'true'
         run: yarn build
 

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -39,7 +39,7 @@ export default defineManifest(async (env) => ({
     "128": "prompts-chat-logo-128.png"
   },
   action: {
-    default_popup: 'index.html?context=popup',
+    default_popup: 'popup.html',
     default_icon: {
       "16": "prompts-chat-logo-16.png",
       "48": "prompts-chat-logo-48.png",
@@ -47,7 +47,7 @@ export default defineManifest(async (env) => ({
     }
   },
   side_panel: {
-    default_path: 'index.html?context=sidepanel',
+    default_path: 'sidepanel.html',
   },
   permissions: [
     'storage',

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/prompts-chat-logo-16.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>prompts.chat</title>
+  </head>
+  <body>
+    <div id="root" data-context="popup"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/prompts-chat-logo-16.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>prompts.chat</title>
+  </head>
+  <body>
+    <div id="root" data-context="sidepanel"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/components/SidePanelNotice.tsx
+++ b/src/components/SidePanelNotice.tsx
@@ -7,8 +7,8 @@ export function SidePanelNotice() {
   const [dismissed, setDismissed] = useState(true);
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const context = urlParams.get('context');
+    const rootElement = document.getElementById('root');
+    const context = rootElement?.dataset.context;
     setIsPopup(context === 'popup');
 
     chrome.storage.local.get('sidepanel_notice_dismissed').then((result) => {


### PR DESCRIPTION
## Summary
Fixes the CI build failure and adds a verification step to prevent broken releases.

## Root Cause
Vite cannot handle query params in manifest paths (`index.html?context=popup`), causing production builds to fail while dev server worked fine.

## Changes

### Build Fix
- Created separate [popup.html](cci:7://file:///Users/fatihsolhan/Desktop/prompts-chat-extension/popup.html:0:0-0:0) and [sidepanel.html](cci:7://file:///Users/fatihsolhan/Desktop/prompts-chat-extension/sidepanel.html:0:0-0:0) entry points
- Each has `data-context` attribute on root div for context detection
- Updated manifest to reference the new HTML files

### CI Improvement
- Added "Verify build" step **before** semantic-release
- If build fails, CI fails early without creating a broken release